### PR TITLE
Standardize all indentation to 4 spaces

### DIFF
--- a/keyboards/ianklug/bemini/keymaps/default/keymap.c
+++ b/keyboards/ianklug/bemini/keymaps/default/keymap.c
@@ -42,7 +42,7 @@ enum layer_names {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [BASE] = LAYOUT(
-/*	K01      K02      K03      K04      K05      K06      K07      K08      K09      K10      K11      K12      K13      */
-	KC_Z,    KC_S,    KC_X,    KC_D,    KC_C,    KC_F,    KC_V,    KC_T,    KC_G,    KC_ENT,  KC_1,    KC_TAB,  KC_LSFT
+/*      K01      K02      K03      K04      K05      K06      K07      K08      K09      K10      K11      K12      K13      */
+        KC_Z,    KC_S,    KC_X,    KC_D,    KC_C,    KC_F,    KC_V,    KC_T,    KC_G,    KC_ENT,  KC_1,    KC_TAB,  KC_LSFT
     )
 };

--- a/keyboards/ianklug/bemini/keymaps/default_p2/keymap.c
+++ b/keyboards/ianklug/bemini/keymaps/default_p2/keymap.c
@@ -42,7 +42,7 @@ enum layer_names {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [BASE] = LAYOUT(
-/*	K01      K02      K03      K04      K05      K06      K07      K08      K09      K10      K11      K12      K13      */
-	KC_DOT,  KC_L,    KC_COMM, KC_K,    KC_M,    KC_J,    KC_N,    KC_H,    KC_B,    KC_TAB,  KC_1,    KC_ENT,  KC_RSFT
+/*      K01      K02      K03      K04      K05      K06      K07      K08      K09      K10      K11      K12      K13      */
+        KC_DOT,  KC_L,    KC_COMM, KC_K,    KC_M,    KC_J,    KC_N,    KC_H,    KC_B,    KC_TAB,  KC_1,    KC_ENT,  KC_RSFT
     )
 };

--- a/keyboards/ianklug/bemini/keymaps/gamepad/keymap.c
+++ b/keyboards/ianklug/bemini/keymaps/gamepad/keymap.c
@@ -43,7 +43,7 @@ bool mode_swap_bms = 0;
 bool mode_swap_keyboard = 0;
 bool mode_swap_ninekey = 0;
 
-/*	bemini key layout, player 1 configuration
+/*      bemini key layout, player 1 configuration
  *      .-----------------------------------------------------------------------------------------.
  *      |                                                                                         |
  *      |                                    .-------.-------.-------.-------.        .-------.   |
@@ -81,21 +81,21 @@ enum layer_names {
 };
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-/*	K01          K02          K03          K04          K05          K06          K07          K08          K09          K10          K11          K12          K13           */
+/*      K01          K02          K03          K04          K05          K06          K07          K08          K09          K10          K11          K12          K13           */
     [STANDARD_P1] = LAYOUT(
-	JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
+        JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
     ),
     [INVERTED_P1] = LAYOUT(
-	JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
+        JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
     ),
     [BMS_P1] = LAYOUT(
-	JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
+        JS_BUTTON12, JS_BUTTON13, JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON10, JS_BUTTON9,  JS_BUTTON8,  TOGGLE_BUTTON
     ),
     [KEYBOARD_P1] = LAYOUT(
-	KC_A,        KC_S,        KC_D,        KC_F,        KC_G,        KC_H,        KC_J,        KC_K,        KC_L,        KC_T,        KC_R,        KC_E,        TOGGLE_BUTTON
+        KC_A,        KC_S,        KC_D,        KC_F,        KC_G,        KC_H,        KC_J,        KC_K,        KC_L,        KC_T,        KC_R,        KC_E,        TOGGLE_BUTTON
     ),
     [NINEKEY_P1] = LAYOUT(
-	JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON7,  JS_BUTTON8,  JS_BUTTON11, JS_BUTTON10, JS_BUTTON9,  KC_NO
+        JS_BUTTON0,  JS_BUTTON1,  JS_BUTTON2,  JS_BUTTON3,  JS_BUTTON4,  JS_BUTTON5,  JS_BUTTON6,  JS_BUTTON7,  JS_BUTTON8,  JS_BUTTON11, JS_BUTTON10, JS_BUTTON9,  KC_NO
     ),
     [STANDARD_P2] = LAYOUT(
         JS_BUTTON13, JS_BUTTON12, JS_BUTTON6,  JS_BUTTON5,  JS_BUTTON4,  JS_BUTTON3,  JS_BUTTON2,  JS_BUTTON1,  JS_BUTTON0,  JS_BUTTON8,  JS_BUTTON9,  JS_BUTTON10, TOGGLE_BUTTON
@@ -110,7 +110,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_DOT,      KC_COMM,     KC_M,        KC_N,        KC_B,        KC_V,        KC_C,        KC_X,        KC_Z,        KC_O,        KC_P,        KC_LBRC,     TOGGLE_BUTTON
     ),
     [NINEKEY_P2] = LAYOUT(
-        JS_BUTTON8, JS_BUTTON7,  JS_BUTTON6,  JS_BUTTON5,  JS_BUTTON4,  JS_BUTTON3,  JS_BUTTON2,  JS_BUTTON1,  JS_BUTTON0,  JS_BUTTON9,   JS_BUTTON10, JS_BUTTON11, KC_NO
+        JS_BUTTON8,  JS_BUTTON7,  JS_BUTTON6,  JS_BUTTON5,  JS_BUTTON4,  JS_BUTTON3,  JS_BUTTON2,  JS_BUTTON1,  JS_BUTTON0,  JS_BUTTON9,  JS_BUTTON10, JS_BUTTON11, KC_NO
     )
 };
 
@@ -118,7 +118,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 void matrix_init_user(void) {
     eeconfig_read_default_layer();
     if (biton32(default_layer_state) == STANDARD_P2) {
-	is_player_two = 1;
+        is_player_two = 1;
     }
 }
 
@@ -148,12 +148,12 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             if (clockwise) {
                 x_axis_val = joystick_status.axes[0] + 1;
                 if (x_axis_val > 127) {
-  	            x_axis_val = -127;
+                    x_axis_val = -127;
                 }
             } else {
                 x_axis_val = joystick_status.axes[0] - 1;
                 if (x_axis_val < -127) {
-	            x_axis_val = 127;
+                    x_axis_val = 127;
                 }
             }
             joystick_status.axes[0] = x_axis_val;
@@ -162,12 +162,12 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
             if (clockwise) {
                 x_axis_val = joystick_status.axes[0] - 1;
                 if (x_axis_val < -127) {
-	            x_axis_val = 127;
+                    x_axis_val = 127;
                 }
             } else {
                 x_axis_val = joystick_status.axes[0] + 1;
                 if (x_axis_val > 127) {
-  	            x_axis_val = -127;
+                    x_axis_val = -127;
                 }
             }
             joystick_status.axes[0] = x_axis_val;
@@ -175,94 +175,94 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
         } else if (layer_state_is(BMS_P1) || layer_state_is(BMS_P2)) {
             uint16_t x_axis_input = 0;
             if (clockwise) {
-	        x_axis_input = 127;
+                x_axis_input = 127;
             } else {
-	        x_axis_input = -127;
+                x_axis_input = -127;
             }
 
             if (x_axis_val == 0) {
                 x_axis_val = x_axis_input;
-		joystick_status.axes[0] = x_axis_input;
+                joystick_status.axes[0] = x_axis_input;
                 joystick_status.status |= JS_UPDATED;
 
                 enc_reverse = 0;
-		hold_timer = timer_read();
+                hold_timer = timer_read();
             } else if (x_axis_val != x_axis_input) {
                 enc_reverse++;
 
-		/* require two consecutive reverse signals to change direction */
-        	if (enc_reverse > 1) {
-	            x_axis_val = x_axis_input;
-	            joystick_status.axes[0] = x_axis_input;
-	            joystick_status.status |= JS_UPDATED;
+                /* require two consecutive reverse signals to change direction */
+                if (enc_reverse > 1) {
+                    x_axis_val = x_axis_input;
+                    joystick_status.axes[0] = x_axis_input;
+                    joystick_status.status |= JS_UPDATED;
 
-	            enc_reverse = 0;
-	            hold_timer = timer_read();
-	        }
+                    enc_reverse = 0;
+                    hold_timer = timer_read();
+                }
             } else {
-	        enc_reverse = 0;
-	        hold_timer = timer_read();
+                enc_reverse = 0;
+                hold_timer = timer_read();
             }
         } else if (layer_state_is(KEYBOARD_P1)) {
             uint16_t mapped_code = 0;
-      	    if (clockwise) {
-		mapped_code = KC_W;
-	    } else {
+            if (clockwise) {
+                mapped_code = KC_W;
+            } else {
                 mapped_code = KC_Q;
-	    }
+            }
 
             if (held_keycode == 0) {
- 	        register_code(mapped_code);
+                register_code(mapped_code);
 
-	        enc_reverse = 0;
-	        held_keycode = mapped_code;
+                enc_reverse = 0;
+                held_keycode = mapped_code;
                 hold_timer = timer_read();
             } else if (held_keycode != mapped_code) {
-	        enc_reverse++;
+                enc_reverse++;
 
-        	/* require two consecutive reverse signals to change direction */
-	        if (enc_reverse > 1) {
+                /* require two consecutive reverse signals to change direction */
+                if (enc_reverse > 1) {
                     unregister_code(held_keycode);
                     register_code(mapped_code);
 
-	  	    enc_reverse = 0;
-		    held_keycode = mapped_code;
+                    enc_reverse = 0;
+                    held_keycode = mapped_code;
                     hold_timer = timer_read();
-  	        }
+                  }
             } else {
-	        enc_reverse = 0;
-	        held_keycode = mapped_code;
+                enc_reverse = 0;
+                held_keycode = mapped_code;
                 hold_timer = timer_read();
             }
         } else if (layer_state_is(KEYBOARD_P2)) {
             uint16_t mapped_code = 0;
-      	    if (clockwise) {
-	        mapped_code = KC_I;
-	    } else {
+            if (clockwise) {
+                mapped_code = KC_I;
+            } else {
                 mapped_code = KC_U;
-	    }
+            }
 
             if (held_keycode == 0) {
- 	        register_code(mapped_code);
+                register_code(mapped_code);
 
-	        enc_reverse = 0;
-	        held_keycode = mapped_code;
+                enc_reverse = 0;
+                held_keycode = mapped_code;
                 hold_timer = timer_read();
             } else if (held_keycode != mapped_code) {
-	        enc_reverse++;
+                enc_reverse++;
 
-        	/* require two consecutive reverse signals to change direction */
-	        if (enc_reverse > 1) {
+                /* require two consecutive reverse signals to change direction */
+                if (enc_reverse > 1) {
                     unregister_code(held_keycode);
                     register_code(mapped_code);
 
-	  	    enc_reverse = 0;
-		    held_keycode = mapped_code;
+                    enc_reverse = 0;
+                    held_keycode = mapped_code;
                     hold_timer = timer_read();
-  	        }
+                }
             } else {
-	        enc_reverse = 0;
-	        held_keycode = mapped_code;
+                enc_reverse = 0;
+                held_keycode = mapped_code;
                 hold_timer = timer_read();
             }
         } else if (layer_state_is(NINEKEY_P1) || layer_state_is(NINEKEY_P2)) {
@@ -276,145 +276,145 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch(keycode){
         case TOGGLE_BUTTON:
-	    if (layer_state_is(STANDARD_P1) || layer_state_is(STANDARD_P2)) {
+            if (layer_state_is(STANDARD_P1) || layer_state_is(STANDARD_P2)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
-	            if (is_toggled) {
-			register_joystick_button(14);
+                    if (is_toggled) {
+                        register_joystick_button(14);
                     } else {
-			register_joystick_button(15);
+                        register_joystick_button(15);
                     }
-	        } else {
-	            if (is_toggled) {
-			unregister_joystick_button(14);
+                } else {
+                    if (is_toggled) {
+                        unregister_joystick_button(14);
                     } else {
-			unregister_joystick_button(15);
+                        unregister_joystick_button(15);
                     }
-	        }
-	    } else if (layer_state_is(INVERTED_P1)) {
+                }
+            } else if (layer_state_is(INVERTED_P1)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
-	            if (is_toggled) {
+                    if (is_toggled) {
                         register_code(KC_LSFT);
                     } else {
                         register_code(KC_LCTL);
                     }
-	        } else {
-	            if (is_toggled) {
+                } else {
+                    if (is_toggled) {
                         unregister_code(KC_LSFT);
                     } else {
                         unregister_code(KC_LCTL);
                     }
-	        }
-	    } else if (layer_state_is(INVERTED_P2)) {
+                }
+            } else if (layer_state_is(INVERTED_P2)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
-	            if (is_toggled) {
+                    if (is_toggled) {
                         register_code(KC_RSFT);
                     } else {
                         register_code(KC_RCTL);
                     }
-	        } else {
-	            if (is_toggled) {
+                } else {
+                    if (is_toggled) {
                         unregister_code(KC_RSFT);
                     } else {
                         unregister_code(KC_RCTL);
                     }
-	        }
-	    } else if (layer_state_is(BMS_P1) || layer_state_is(BMS_P2)) {
+                }
+            } else if (layer_state_is(BMS_P1) || layer_state_is(BMS_P2)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
                     if (is_toggled) {
-			register_joystick_button(14);
+                        register_joystick_button(14);
                     } else {
-			register_joystick_button(15);
+                        register_joystick_button(15);
                     }
                 } else {
                     if (is_toggled) {
-			unregister_joystick_button(14);
+                        unregister_joystick_button(14);
                     } else {
-			unregister_joystick_button(15);
+                        unregister_joystick_button(15);
                     }
                 }
-	    } else if (layer_state_is(KEYBOARD_P1)) {
+            } else if (layer_state_is(KEYBOARD_P1)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
-	            if (is_toggled) {
+                    if (is_toggled) {
                         register_code(KC_W);
                     } else {
                         register_code(KC_Q);
                     }
-	        } else {
-	            if (is_toggled) {
+                } else {
+                    if (is_toggled) {
                         unregister_code(KC_W);
                     } else {
                         unregister_code(KC_Q);
                     }
-	        }
-	    } else if (layer_state_is(KEYBOARD_P2)) {
+                }
+            } else if (layer_state_is(KEYBOARD_P2)) {
                 if (record->event.pressed) {
                     is_toggled ^= 1;
-	            if (is_toggled) {
+                    if (is_toggled) {
                         register_code(KC_I);
                     } else {
                         register_code(KC_U);
                     }
-	        } else {
-	            if (is_toggled) {
+                } else {
+                    if (is_toggled) {
                         unregister_code(KC_I);
                     } else {
                         unregister_code(KC_U);
                     }
-	        }
-	    } else if (layer_state_is(NINEKEY_P1) || layer_state_is(NINEKEY_P2)) {
-		/* not bound */
-	    }
+                }
+            } else if (layer_state_is(NINEKEY_P1) || layer_state_is(NINEKEY_P2)) {
+                /* not bound */
+            }
             break;
-	case KC_E: case KC_R: case KC_T: case KC_O: case KC_P: case KC_LBRC: case JS_BUTTON8: case JS_BUTTON9: case JS_BUTTON10: case JS_BUTTON11:
-	    /* K10, K11, K12 */
+        case KC_E: case KC_R: case KC_T: case KC_O: case KC_P: case KC_LBRC: case JS_BUTTON8: case JS_BUTTON9: case JS_BUTTON10: case JS_BUTTON11:
+            /* K10, K11, K12 */
             if (record->event.pressed)
                 mode_swap++;
             else
                 mode_swap--;
-	    break;
-	case KC_A: case KC_DOT: case JS_BUTTON12: case JS_BUTTON13:
-	    /* White 1 */
-	    if (record->event.pressed)
+            break;
+        case KC_A: case KC_DOT: case JS_BUTTON12: case JS_BUTTON13:
+            /* White 1 */
+            if (record->event.pressed)
                 mode_swap_ninekey = 1;
             else
                 mode_swap_ninekey = 0;
             break;
-	case KC_D: case KC_Z: case JS_BUTTON0:
-	    /* White 2 */
-	    if (record->event.pressed)
+        case KC_D: case KC_Z: case JS_BUTTON0:
+            /* White 2 */
+            if (record->event.pressed)
                 mode_swap_standard = 1;
             else
                 mode_swap_standard = 0;
             break;
-	case KC_G: case KC_C: case JS_BUTTON2:
-	    /* White 3 */
-	    if (record->event.pressed)
+        case KC_G: case KC_C: case JS_BUTTON2:
+            /* White 3 */
+            if (record->event.pressed)
                 mode_swap_inverted = 1;
             else
                 mode_swap_inverted = 0;
             break;
-	case KC_J: case KC_B: case JS_BUTTON4:
-	    /* White 4 */
-	    if (record->event.pressed)
+        case KC_J: case KC_B: case JS_BUTTON4:
+            /* White 4 */
+            if (record->event.pressed)
                 mode_swap_bms = 1;
             else
                 mode_swap_bms = 0;
             break;
-	case KC_L: case KC_M: case JS_BUTTON6:
-	    /* White 5 */
-	    if (record->event.pressed)
+        case KC_L: case KC_M: case JS_BUTTON6:
+            /* White 5 */
+            if (record->event.pressed)
                 mode_swap_keyboard = 1;
             else
                 mode_swap_keyboard = 0;
             break;
-	case KC_F: case KC_H: case KC_N: case KC_V: case JS_BUTTON1: case JS_BUTTON3: case JS_BUTTON5:
-	    /* Black 2 + Black 3 */
-	    if (record->event.pressed)
+        case KC_F: case KC_H: case KC_N: case KC_V: case JS_BUTTON1: case JS_BUTTON3: case JS_BUTTON5:
+            /* Black 2 + Black 3 */
+            if (record->event.pressed)
                 mode_swap_p2++;
             else
                 mode_swap_p2--;
@@ -425,55 +425,55 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
      * switch player mode when middle two black keys + e keys are pressed
      */
     if (mode_swap == 3) {
-	/* save default player mode to eeprom */
-	if (mode_swap_p2 == 2) {
-	    is_player_two ^= 1;
-	    if (is_player_two) {
-		set_single_persistent_default_layer(STANDARD_P2);
-		layer_move(STANDARD_P2);
-	    } else {
-		set_single_persistent_default_layer(STANDARD_P1);
-		layer_move(STANDARD_P1);
-	    }
-	}
+        /* save default player mode to eeprom */
+        if (mode_swap_p2 == 2) {
+            is_player_two ^= 1;
+            if (is_player_two) {
+                set_single_persistent_default_layer(STANDARD_P2);
+                layer_move(STANDARD_P2);
+            } else {
+                set_single_persistent_default_layer(STANDARD_P1);
+                layer_move(STANDARD_P1);
+            }
+        }
 
         if (is_player_two) {
-	    if (mode_swap_standard == 1) {
+            if (mode_swap_standard == 1) {
                 layer_move(STANDARD_P2);
-	    } else if (mode_swap_inverted == 1) {
-	        layer_move(INVERTED_P2);
-	    } else if (mode_swap_bms == 1) {
-	        layer_move(BMS_P2);
-	    } else if (mode_swap_keyboard == 1) {
-	        layer_move(KEYBOARD_P2);
-	    } else if (mode_swap_ninekey == 1) {
-	        layer_move(NINEKEY_P2);
-	    }
+            } else if (mode_swap_inverted == 1) {
+                layer_move(INVERTED_P2);
+            } else if (mode_swap_bms == 1) {
+                layer_move(BMS_P2);
+            } else if (mode_swap_keyboard == 1) {
+                layer_move(KEYBOARD_P2);
+            } else if (mode_swap_ninekey == 1) {
+                layer_move(NINEKEY_P2);
+            }
         } else {
-	    if (mode_swap_standard == 1) {
+            if (mode_swap_standard == 1) {
                 layer_move(STANDARD_P1);
-	    } else if (mode_swap_inverted == 1) {
-	        layer_move(INVERTED_P1);
-	    } else if (mode_swap_bms == 1) {
-	        layer_move(BMS_P1);
-	    } else if (mode_swap_keyboard == 1) {
-	        layer_move(KEYBOARD_P1);
-	    } else if (mode_swap_ninekey == 1) {
-	        layer_move(NINEKEY_P1);
-	    }
-	}
+            } else if (mode_swap_inverted == 1) {
+                layer_move(INVERTED_P1);
+            } else if (mode_swap_bms == 1) {
+                layer_move(BMS_P1);
+            } else if (mode_swap_keyboard == 1) {
+                layer_move(KEYBOARD_P1);
+            } else if (mode_swap_ninekey == 1) {
+                layer_move(NINEKEY_P1);
+            }
+        }
 
-	/* reset everything after layer switch */
+        /* reset everything after layer switch */
         x_axis_val = 0;
         hold_timer = 0;
         held_keycode = 0;
-	enc_reverse = 0;
-	is_toggled = 0;
+        enc_reverse = 0;
+        is_toggled = 0;
 
         joystick_status.axes[0] = 0;
         joystick_status.status |= JS_UPDATED;
 
-	clear_keyboard();
+        clear_keyboard();
     }
     return true;
 }

--- a/keyboards/ianklug/bemini/rules.mk
+++ b/keyboards/ianklug/bemini/rules.mk
@@ -16,4 +16,4 @@ NKRO_ENABLE = yes           # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 RGBLIGHT_ENABLE = no        # Enable keyboard RGB underglow
 AUDIO_ENABLE = no           # Audio output
-ENCODER_ENABLE = yes	    # Rotary encoder
+ENCODER_ENABLE = yes        # Rotary encoder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I noticed when playing with the code that there was some mixed tab/space indentation. This just tidies it up so that all indentation is using the QMK 4-space standard. Nothing apart from whitespace is changed, and I checked that all three keymaps still build fine to double-check that I didn't break anything. Thanks very much!

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
